### PR TITLE
dash after last dot for JAVACLASS

### DIFF
--- a/pygrok/patterns/java
+++ b/pygrok/patterns/java
@@ -1,3 +1,3 @@
-JAVACLASS (?:[a-zA-Z0-9-]+\.)+[A-Za-z0-9$]+
+JAVACLASS (?:[a-zA-Z0-9-]+\.)+[-A-Za-z0-9$]+
 JAVAFILE (?:[A-Za-z0-9_.-]+)
 JAVASTACKTRACEPART at %{JAVACLASS:class}\.%{WORD:method}\(%{JAVAFILE:file}:%{NUMBER:line}\)


### PR DESCRIPTION
Allow dash after last dot for JAVACLASS pattern.
We hat the Issue of not being able to parse some log-messages due to the occurring of a dash within classname.
In our case the class is called "c.a.s.thrift-utils". After the proposed change grok is able to process the message correctly.
