### PR TITLE
Fix UnicodeDecodeError on pattern file loading

### DIFF
--- a/pygrok/pygrok.py
+++ b/pygrok/pygrok.py
@@ -90,7 +90,10 @@ def _load_patterns_from_file(file):
     """
     """
     patterns = {}
-    with open(file, 'r') as f:
+    file_encoding = 'ascii'
+    if file == 'grok-patterns':
+        file_encoding = 'utf-8'
+    with open(file, 'r', encoding=file_encoding) as f:
         for l in f:
             l = l.strip()
             if l == '' or l.startswith('#'):


### PR DESCRIPTION
This is a bit brute-force, but conforms to the idea that one should explicitly
specify the encoding for external data files when they are opened.