### PR TITLE
Use pkg_resources to access default patterns and mark as zip_safe.

### DIFF
--- a/pygrok/pygrok.py
+++ b/pygrok/pygrok.py
@@ -4,8 +4,9 @@ except ImportError as e:
     # If you import re, grok_match can't handle regular expression containing atomic group(?>)
     import re
 import os
+import pkg_resources
 
-DEFAULT_PATTERNS_DIRS = [os.path.dirname(os.path.abspath(__file__)) + '/patterns']
+DEFAULT_PATTERNS_DIRS = [pkg_resources.resource_filename(__name__, 'patterns')]
 
 
 class Grok(object):

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(name = 'pygrok',
     license = 'MIT',
     packages = ['pygrok'],
     include_package_data = True,
+    zip_safe = True,
     keywords = ['python grok', 'regex'], # arbitrary keywords
     download_url = 'https://github.com/garyelephant/pygrok/tarball/v1.0.0',
     install_requires=['regex']


### PR DESCRIPTION
Would be nice if this package can be installed as a zipped egg. Turns out not many changes are required to allow that...

I've sometimes seen this package installed as a zip in a virtualenv, but I couldn't find out under which circumstances. Needless to say, the loading of the default patterns failed, so this is technically a bugfix.