### PR TITLE
Add support for re flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Some of the pattern you can use are listed here:
 
 other patterns such as `IP`, `HOSTNAME`, `URIPATH`, `DATE`, `TIMESTAMP_ISO8601`, `COMMONAPACHELOG`..
 ```
+
+You can also pass re flags to Grok (e.g. `Grok('%{GREEDYDATA:txt}', flags=re.M|re.S)`).
+
 See All patterns [here](./pygrok/patterns)
 
 You can also have custom pattern, see [these codes](https://github.com/garyelephant/pygrok/blob/master/tests/test_pygrok.py#L97).
@@ -82,14 +85,14 @@ pattern files come from [logstash filter grok's pattern files](https://github.co
 
 Contribute
 ---
-*   You are encouraged to [fork](https://github.com/garyelephant/pygrok/fork), improve the code, then make a pull request. 
+*   You are encouraged to [fork](https://github.com/garyelephant/pygrok/fork), improve the code, then make a pull request.
 *   [Issue tracker](https://github.com/garyelephant/pygrok/issues)
 
 Get Help
 ---
     mail:garygaowork@gmail.com
     twitter:@garyelephant
-    
+
 Contributors
 ---
   Thanks to [all contributors](https://github.com/garyelephant/pygrok/graphs/contributors)

--- a/pygrok/pygrok.py
+++ b/pygrok/pygrok.py
@@ -11,11 +11,12 @@ DEFAULT_PATTERNS_DIRS = [pkg_resources.resource_filename(__name__, 'patterns')]
 
 
 class Grok(object):
-    def __init__(self, pattern, custom_patterns_dir=None, custom_patterns={}, fullmatch=True):
+    def __init__(self, pattern, custom_patterns_dir=None, custom_patterns={}, fullmatch=True, flags=0):
         self.pattern = pattern
         self.custom_patterns_dir = custom_patterns_dir
         self.predefined_patterns = _reload_patterns(DEFAULT_PATTERNS_DIRS)
         self.fullmatch = fullmatch
+        self.flags = flags
 
         custom_pats = {}
         if custom_patterns_dir is not None:
@@ -85,7 +86,7 @@ class Grok(object):
             if re.search('%{\w+(:\w+)?}', py_regex_pattern) is None:
                 break
 
-        self.regex_obj = re.compile(py_regex_pattern)
+        self.regex_obj = re.compile(py_regex_pattern, flags=self.flags)
 
 def _wrap_pattern_name(pat_name):
     return '%{' + pat_name + '}'

--- a/tests/test_pygrok.py
+++ b/tests/test_pygrok.py
@@ -1,4 +1,9 @@
 from pygrok import Grok
+try:
+   import regex as re
+except ImportError as e:
+   # If you import re, grok_match can't handle regular expression containing atomic group(?>)
+   import re
 
 
 def test_one_pat():
@@ -57,6 +62,12 @@ def test_one_pat():
     grok = Grok(pat)
     m = grok.match(text)
     assert m == {'birthyear': 1989}, 'grok match failed:%s, %s' % (text, pat, )
+
+    text = 'some multiline\ntext'
+    pat = '%{GREEDYDATA:txt}'
+    grok = Grok(pat, flags=re.M | re.S)
+    m = grok.match(text)
+    assert m == {'txt': 'some multiline\ntext'}, 'grok match failed:%s, %s' % (text, pat, )
 
 
 def test_multiple_pats():


### PR DESCRIPTION
When working with multiline strings, re requires extra flags in order to
interpret new line characters differently.

e.g. https://docs.python.org/3/library/re.html#re.M

With this change you can optionally pass re flags when initalizing Grok objects.

    grok = Grok(pat, flags=re.M|re.S)

I've successfully tested this change with both the re and regex package.