### PR TITLE
pattern: fix JAVASTACKTRACEPART bug

### DIFF
--- a/pygrok/patterns/java
+++ b/pygrok/patterns/java
@@ -9,7 +9,7 @@ JAVASTACKTRACEPART %{SPACE}at %{JAVACLASS:class}\.%{JAVAMETHOD:method}\(%{JAVAFI
 JAVATHREAD (?:[A-Z]{2}-Processor[\d]+)
 JAVACLASS (?:[a-zA-Z0-9-]+\.)+[A-Za-z0-9$]+
 JAVAFILE (?:[A-Za-z0-9_.-]+)
-JAVASTACKTRACEPART at %{JAVACLASS:class}\.%{WORD:method}\(%{JAVAFILE:file}:%{NUMBER:line}\)
+JAVASTACKTRACEPART at %{JAVACLASS:class}\.%{JAVAMETHOD:method}\(%{JAVAFILE:file}:%{NUMBER:line}\)
 JAVALOGMESSAGE (.*)
 # MMM dd, yyyy HH:mm:ss eg: Jan 9, 2014 7:13:13 AM
 CATALINA_DATESTAMP %{MONTH} %{MONTHDAY}, 20%{YEAR} %{HOUR}:?%{MINUTE}(?::?%{SECOND}) (?:AM|PM)


### PR DESCRIPTION
JAVASTACKTRACEPART didn't pick up methods with $ in their name
(which can happen with dynamically generated methods).